### PR TITLE
Go back to main keyboard after space setting

### DIFF
--- a/app/src/main/java/it/keybeeproject/keybee/activity/SettingsActivity.java
+++ b/app/src/main/java/it/keybeeproject/keybee/activity/SettingsActivity.java
@@ -37,14 +37,14 @@ public class SettingsActivity extends AppCompatActivity {
             textLayoutIntro, textSelectedCurrency, text_theme_subsription/*, textAutoCorrection, textAutoCompletion, textLanguageDictionary*/;
     private LinearLayout linearEnable, linearTutorial, linearProjectInfo, linearSize, linearAlignment, linearTheme,
             linearLayout, linearKeybee, linearGithub, linearKeybeecontest, linearFacebook, linearTwitter, linearLinkedIn, linearDonate, linearCurrency;
-    private RelativeLayout relative_topgap,relativeFullWidth, relativeAnySpace, relativeLateralGap, relativeSound, relativeVibra, relativeDotSpace, linear_free_theme,
+    private RelativeLayout relative_topgap,relativeFullWidth, relativeMainAfterSpace, relativeLateralGap, relativeSound, relativeVibra, relativeDotSpace, linear_free_theme,
             relativePreview, relativeTwipe, relativeCursor, relativeDotApostophe, relativeTextCorrection, relativeTextAutoCapitalization, relative_notification;
     private ImageView img_apply_theme;
     private String[] arrSizeTitle, arrAlignmentTitle, arrLayoutTitle, arrCurrencyTitle, arrLanguageCode;
     private float[] arrSizeValue;
     private int currentKeyboardLayout;
     private CheckBox check_topgap,checkFullWidth, checkLateralGapFill, checkSound, checkVibra, checkDotSpace, checkPreview, checkTwipe,
-            checkCursor, checkDotApostophe, checkTextSuggestion, checkTextAutoCapitalization, check_notification, checkAnySpace;
+            checkCursor, checkDotApostophe, checkTextSuggestion, checkTextAutoCapitalization, check_notification, checkMainAfterSpace;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -103,7 +103,7 @@ public class SettingsActivity extends AppCompatActivity {
         relativeSound = findViewById(R.id.relative_sound);
         relativeVibra = findViewById(R.id.relative_vibra);
         relativeDotSpace = findViewById(R.id.relative_dotSpace);
-        relativeAnySpace = findViewById(R.id.relative_anySpace);
+        relativeMainAfterSpace = findViewById(R.id.relative_mainAfterSpace);
         relativePreview = findViewById(R.id.relative_preview);
         relativeTwipe = findViewById(R.id.relative_twipe);
         relativeCursor = findViewById(R.id.relative_cursor);
@@ -119,7 +119,7 @@ public class SettingsActivity extends AppCompatActivity {
         checkSound = findViewById(R.id.check_sound);
         checkVibra = findViewById(R.id.check_vibra);
         checkDotSpace = findViewById(R.id.check_dotSpace);
-        checkAnySpace = findViewById(R.id.check_anySpace);
+        checkMainAfterSpace = findViewById(R.id.check_mainAfterSpace);
         checkPreview = findViewById(R.id.check_preview);
         checkTwipe = findViewById(R.id.check_twipe);
         checkCursor = findViewById(R.id.check_cursor);
@@ -253,12 +253,12 @@ public class SettingsActivity extends AppCompatActivity {
             }
         });
 
-        relativeAnySpace.setOnClickListener(new View.OnClickListener() {
+        relativeMainAfterSpace.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
-                checkAnySpace.setChecked(!checkAnySpace.isChecked());
-                PrefData.setBooleanPrefs(SettingsActivity.this, PrefData.KEY_IS_ANY_SPACE_ENABLED_B, checkAnySpace.isChecked());
-                enableDotSpaceSettings(!checkAnySpace.isChecked());
+                checkMainAfterSpace.setChecked(!checkMainAfterSpace.isChecked());
+                PrefData.setBooleanPrefs(SettingsActivity.this, PrefData.KEY_IS_MAIN_AFTER_SPACE_ENABLED_B, checkMainAfterSpace.isChecked());
+                enableDotSpaceSettings(!checkMainAfterSpace.isChecked());
             }
         });
 
@@ -474,11 +474,11 @@ public class SettingsActivity extends AppCompatActivity {
 
     private void initTextSettings() {
         checkDotSpace.setChecked(PrefData.getBooleanPrefs(SettingsActivity.this, PrefData.KEY_IS_DOT_SPACE_ENABLED_B, true));
-        checkAnySpace.setChecked(PrefData.getBooleanPrefs(SettingsActivity.this, PrefData.KEY_IS_ANY_SPACE_ENABLED_B, false));
+        checkMainAfterSpace.setChecked(PrefData.getBooleanPrefs(SettingsActivity.this, PrefData.KEY_IS_MAIN_AFTER_SPACE_ENABLED_B, false));
         checkPreview.setChecked(PrefData.getBooleanPrefs(SettingsActivity.this, PrefData.KEY_IS_PREVIEW_ENABLED_B, true));
         checkTextSuggestion.setChecked(PrefData.getBooleanPrefs(SettingsActivity.this, PrefData.KEY_IS_TEXT_SUGGESTION_ENABLED_B));
         checkTextAutoCapitalization.setChecked(PrefData.getBooleanPrefs(SettingsActivity.this, PrefData.KEY_IS_TEXT_AUTOCAPITALIZATION_ENABLED_B));
-        enableDotSpaceSettings(!checkAnySpace.isChecked());
+        enableDotSpaceSettings(!checkMainAfterSpace.isChecked());
     }
 
     private void showCurrencyDialog() {

--- a/app/src/main/java/it/keybeeproject/keybee/activity/SettingsActivity.java
+++ b/app/src/main/java/it/keybeeproject/keybee/activity/SettingsActivity.java
@@ -33,18 +33,18 @@ import it.keybeeproject.keybee.utility.Utility;
 
 public class SettingsActivity extends AppCompatActivity {
 
-    private TextView textSize, textSizeIntro, textAlignment, textAlignmentIntro, textLateralGap, textThemeIntro,
+    private TextView textSize, textSizeIntro, textAlignment, textAlignmentIntro, textLateralGap, textThemeIntro, textDotSpace,
             textLayoutIntro, textSelectedCurrency, text_theme_subsription/*, textAutoCorrection, textAutoCompletion, textLanguageDictionary*/;
     private LinearLayout linearEnable, linearTutorial, linearProjectInfo, linearSize, linearAlignment, linearTheme,
             linearLayout, linearKeybee, linearGithub, linearKeybeecontest, linearFacebook, linearTwitter, linearLinkedIn, linearDonate, linearCurrency;
-    private RelativeLayout relative_topgap,relativeFullWidth, relativeLateralGap, relativeSound, relativeVibra, relativeDotSpace, linear_free_theme,
+    private RelativeLayout relative_topgap,relativeFullWidth, relativeAnySpace, relativeLateralGap, relativeSound, relativeVibra, relativeDotSpace, linear_free_theme,
             relativePreview, relativeTwipe, relativeCursor, relativeDotApostophe, relativeTextCorrection, relativeTextAutoCapitalization, relative_notification;
     private ImageView img_apply_theme;
     private String[] arrSizeTitle, arrAlignmentTitle, arrLayoutTitle, arrCurrencyTitle, arrLanguageCode;
     private float[] arrSizeValue;
     private int currentKeyboardLayout;
     private CheckBox check_topgap,checkFullWidth, checkLateralGapFill, checkSound, checkVibra, checkDotSpace, checkPreview, checkTwipe,
-            checkCursor, checkDotApostophe, checkTextSuggestion, checkTextAutoCapitalization, check_notification;
+            checkCursor, checkDotApostophe, checkTextSuggestion, checkTextAutoCapitalization, check_notification, checkAnySpace;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -77,6 +77,7 @@ public class SettingsActivity extends AppCompatActivity {
         textSelectedCurrency = findViewById(R.id.text_selectedCurrency);
         textLateralGap = findViewById(R.id.text_lateralGap);
         text_theme_subsription = findViewById(R.id.text_theme_subsription);
+        textDotSpace = findViewById(R.id.text_dotSpace);
 
         linearEnable = findViewById(R.id.linear_enable);
         linearTutorial = findViewById(R.id.linear_tutorial);
@@ -102,6 +103,7 @@ public class SettingsActivity extends AppCompatActivity {
         relativeSound = findViewById(R.id.relative_sound);
         relativeVibra = findViewById(R.id.relative_vibra);
         relativeDotSpace = findViewById(R.id.relative_dotSpace);
+        relativeAnySpace = findViewById(R.id.relative_anySpace);
         relativePreview = findViewById(R.id.relative_preview);
         relativeTwipe = findViewById(R.id.relative_twipe);
         relativeCursor = findViewById(R.id.relative_cursor);
@@ -117,6 +119,7 @@ public class SettingsActivity extends AppCompatActivity {
         checkSound = findViewById(R.id.check_sound);
         checkVibra = findViewById(R.id.check_vibra);
         checkDotSpace = findViewById(R.id.check_dotSpace);
+        checkAnySpace = findViewById(R.id.check_anySpace);
         checkPreview = findViewById(R.id.check_preview);
         checkTwipe = findViewById(R.id.check_twipe);
         checkCursor = findViewById(R.id.check_cursor);
@@ -247,6 +250,15 @@ public class SettingsActivity extends AppCompatActivity {
             public void onClick(View view) {
                 checkDotSpace.setChecked(!checkDotSpace.isChecked());
                 PrefData.setBooleanPrefs(SettingsActivity.this, PrefData.KEY_IS_DOT_SPACE_ENABLED_B, checkDotSpace.isChecked());
+            }
+        });
+
+        relativeAnySpace.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                checkAnySpace.setChecked(!checkAnySpace.isChecked());
+                PrefData.setBooleanPrefs(SettingsActivity.this, PrefData.KEY_IS_ANY_SPACE_ENABLED_B, checkAnySpace.isChecked());
+                enableDotSpaceSettings(!checkAnySpace.isChecked());
             }
         });
 
@@ -462,9 +474,11 @@ public class SettingsActivity extends AppCompatActivity {
 
     private void initTextSettings() {
         checkDotSpace.setChecked(PrefData.getBooleanPrefs(SettingsActivity.this, PrefData.KEY_IS_DOT_SPACE_ENABLED_B, true));
+        checkAnySpace.setChecked(PrefData.getBooleanPrefs(SettingsActivity.this, PrefData.KEY_IS_ANY_SPACE_ENABLED_B, false));
         checkPreview.setChecked(PrefData.getBooleanPrefs(SettingsActivity.this, PrefData.KEY_IS_PREVIEW_ENABLED_B, true));
         checkTextSuggestion.setChecked(PrefData.getBooleanPrefs(SettingsActivity.this, PrefData.KEY_IS_TEXT_SUGGESTION_ENABLED_B));
         checkTextAutoCapitalization.setChecked(PrefData.getBooleanPrefs(SettingsActivity.this, PrefData.KEY_IS_TEXT_AUTOCAPITALIZATION_ENABLED_B));
+        enableDotSpaceSettings(!checkAnySpace.isChecked());
     }
 
     private void showCurrencyDialog() {
@@ -602,6 +616,12 @@ public class SettingsActivity extends AppCompatActivity {
         textAlignment.setTextColor(textColor);
         relativeLateralGap.setEnabled(enable);
         textLateralGap.setTextColor(textColor);
+    }
+
+    private void enableDotSpaceSettings(boolean enable) {
+        int textColor = enable ? getResources().getColor(R.color.black) : getResources().getColor(R.color.text_gray);
+        relativeDotSpace.setEnabled(enable);
+        textDotSpace.setTextColor(textColor);
     }
 
     @Override

--- a/app/src/main/java/it/keybeeproject/keybee/activity/SettingsActivity.java
+++ b/app/src/main/java/it/keybeeproject/keybee/activity/SettingsActivity.java
@@ -620,8 +620,10 @@ public class SettingsActivity extends AppCompatActivity {
 
     private void enableDotSpaceSettings(boolean enable) {
         int textColor = enable ? getResources().getColor(R.color.black) : getResources().getColor(R.color.text_gray);
+        float checkAlpha = enable ? 1.0f : 0.4f;
         relativeDotSpace.setEnabled(enable);
         textDotSpace.setTextColor(textColor);
+        checkDotSpace.setAlpha(checkAlpha);
     }
 
     @Override

--- a/app/src/main/java/it/keybeeproject/keybee/service/KeyboardService.java
+++ b/app/src/main/java/it/keybeeproject/keybee/service/KeyboardService.java
@@ -111,7 +111,7 @@ public class KeyboardService extends InputMethodService implements
             currentAlignment, lastMoveId = -1, lastDownId, bgEmoji, hMove, candidateHeight = 0;
     private boolean isTopGap,isFullWidth, isShiftOn, isCapsLockOn, isSoundEnabled, isVibraEnabled, isDotSpaceEnabled,
             isPreviewOn, isMoved, isSizeChanged, isTwipeEnabled, isFirstButtonReset, isCursorEnabled, isCursorModeOn,
-            isTextSuggestionEnabled, isCandidateClicked, isAutocapitalizationEnable, isAnySpaceEnabled;
+            isTextSuggestionEnabled, isCandidateClicked, isAutocapitalizationEnable, isMainAfterSpaceEnabled;
     private boolean isActionDownCalled = false; // If user clicks outside of keyboard then text should not appear.For that ACTION_DOWN will be called but flag will not be true so that ACTION_UP will be called but due to condition code will not be execute.
     private final char space = 32;
     private float lastX, lastY, keyboardSize;
@@ -208,7 +208,7 @@ public class KeyboardService extends InputMethodService implements
         isSoundEnabled = PrefData.getBooleanPrefs(this, PrefData.KEY_IS_SOUND_ENABLED_B);
         isVibraEnabled = PrefData.getBooleanPrefs(this, PrefData.KEY_IS_VIBRA_ENABLED_B);
         isDotSpaceEnabled = PrefData.getBooleanPrefs(this, PrefData.KEY_IS_DOT_SPACE_ENABLED_B, true);
-        isAnySpaceEnabled = PrefData.getBooleanPrefs(this, PrefData.KEY_IS_ANY_SPACE_ENABLED_B, true);
+        isMainAfterSpaceEnabled = PrefData.getBooleanPrefs(this, PrefData.KEY_IS_MAIN_AFTER_SPACE_ENABLED_B, true);
         isPreviewOn = PrefData.getBooleanPrefs(this, PrefData.KEY_IS_PREVIEW_ENABLED_B, true);
         isTwipeEnabled = PrefData.getBooleanPrefs(this, PrefData.KEY_IS_TWIPE_ENABLED_B, true);
         isCursorEnabled = PrefData.getBooleanPrefs(this, PrefData.KEY_IS_CURSOR_ENABLED_B, true);
@@ -584,7 +584,7 @@ public class KeyboardService extends InputMethodService implements
                         /**
                          * Check for punctuation + space
                          */
-                        if (isAnySpaceEnabled &&
+                        if (isMainAfterSpaceEnabled &&
                                 currentText.charAt(1) == ' ' &&
                                 ArrayUtils.contains(PUNCTUATION_CHARS_REQUIRING_CAPITALIZATION, currentText.charAt(0))) {
                             isShiftOn = true;
@@ -1462,7 +1462,7 @@ public class KeyboardService extends InputMethodService implements
         /**
          * Check for space after any character, and switch to abc layout
          */
-        if (isAnySpaceEnabled && code == space) {
+        if (isMainAfterSpaceEnabled && code == space) {
             // If anyone presses space and the previous character was punctuation, then switch back to main
             // We should enable shift for punctuation that should be capitalized after, if they want autocapitalization
             Character previousChar = inputConnection.getTextBeforeCursor(2, 0).charAt(0);
@@ -1555,8 +1555,8 @@ public class KeyboardService extends InputMethodService implements
             case PrefData.KEY_IS_DOT_SPACE_ENABLED_B:
                 isDotSpaceEnabled = PrefData.getBooleanPrefs(this, PrefData.KEY_IS_DOT_SPACE_ENABLED_B);
                 break;
-            case PrefData.KEY_IS_ANY_SPACE_ENABLED_B:
-                isAnySpaceEnabled = PrefData.getBooleanPrefs(this, PrefData.KEY_IS_ANY_SPACE_ENABLED_B);
+            case PrefData.KEY_IS_MAIN_AFTER_SPACE_ENABLED_B:
+                isMainAfterSpaceEnabled = PrefData.getBooleanPrefs(this, PrefData.KEY_IS_MAIN_AFTER_SPACE_ENABLED_B);
                 break;
             case PrefData.KEY_IS_PREVIEW_ENABLED_B:
                 isPreviewOn = PrefData.getBooleanPrefs(this, PrefData.KEY_IS_PREVIEW_ENABLED_B);

--- a/app/src/main/java/it/keybeeproject/keybee/service/KeyboardService.java
+++ b/app/src/main/java/it/keybeeproject/keybee/service/KeyboardService.java
@@ -53,6 +53,8 @@ import it.keybeeproject.keybee.view.TextViewCustom;
 import static android.view.inputmethod.InputConnection.CURSOR_UPDATE_MONITOR;
 import static androidx.annotation.Dimension.SP;
 
+import com.google.android.gms.common.util.ArrayUtils;
+
 /**
  * Created by c161 on 22/07/16.
  */
@@ -100,13 +102,16 @@ public class KeyboardService extends InputMethodService implements
     private long currentRepeatInterval = ButtonHexagon.INTERVAL_REPEAT_INITIAL;
     private final int buttonGap = 2; // Must be an even number
     //	private final int buttonGap = 0; // Must be an even number
+
+    // A space after one of these characters should be capitalized
+    public static final Character[] PUNCTUATION_CHARS_REQUIRING_CAPITALIZATION = {'.', '!', '?'};
     private final int cursorThresholdH = 20;
     private final int cursorThresholdV = 80;
     private int keyboardTopPadding, keyboardHeight, keyboardWidth, currentLanguageLayout, currentLanguage, currentLayout,
             currentAlignment, lastMoveId = -1, lastDownId, bgEmoji, hMove, candidateHeight = 0;
     private boolean isTopGap,isFullWidth, isShiftOn, isCapsLockOn, isSoundEnabled, isVibraEnabled, isDotSpaceEnabled,
             isPreviewOn, isMoved, isSizeChanged, isTwipeEnabled, isFirstButtonReset, isCursorEnabled, isCursorModeOn,
-            isTextSuggestionEnabled, isCandidateClicked, isAutocapitalizationEnable;
+            isTextSuggestionEnabled, isCandidateClicked, isAutocapitalizationEnable, isAnySpaceEnabled;
     private boolean isActionDownCalled = false; // If user clicks outside of keyboard then text should not appear.For that ACTION_DOWN will be called but flag will not be true so that ACTION_UP will be called but due to condition code will not be execute.
     private final char space = 32;
     private float lastX, lastY, keyboardSize;
@@ -203,6 +208,7 @@ public class KeyboardService extends InputMethodService implements
         isSoundEnabled = PrefData.getBooleanPrefs(this, PrefData.KEY_IS_SOUND_ENABLED_B);
         isVibraEnabled = PrefData.getBooleanPrefs(this, PrefData.KEY_IS_VIBRA_ENABLED_B);
         isDotSpaceEnabled = PrefData.getBooleanPrefs(this, PrefData.KEY_IS_DOT_SPACE_ENABLED_B, true);
+        isAnySpaceEnabled = PrefData.getBooleanPrefs(this, PrefData.KEY_IS_ANY_SPACE_ENABLED_B, true);
         isPreviewOn = PrefData.getBooleanPrefs(this, PrefData.KEY_IS_PREVIEW_ENABLED_B, true);
         isTwipeEnabled = PrefData.getBooleanPrefs(this, PrefData.KEY_IS_TWIPE_ENABLED_B, true);
         isCursorEnabled = PrefData.getBooleanPrefs(this, PrefData.KEY_IS_CURSOR_ENABLED_B, true);
@@ -1445,9 +1451,25 @@ public class KeyboardService extends InputMethodService implements
         }
 
         /**
+         * Check for space after any character, and switch to abc layout
+         */
+        if (isAnySpaceEnabled && code == space) {
+            // If anyone presses space and the previous character was punctuation, then switch back to main
+            // We should enable shift for punctuation that should be capitalized after, if they want autocapitalization
+            Character previousChar = inputConnection.getTextBeforeCursor(2, 0).charAt(0);
+            if (ArrayUtils.contains(PUNCTUATION_CHARS_REQUIRING_CAPITALIZATION, previousChar)) {
+                isShiftOn = true;
+                updateOnShift();
+            }
+
+            if (currentLayout == PrefData.VAL_LAYOUT_NUMBER || currentLayout == PrefData.VAL_LAYOUT_SYMBOL) {
+                updateOnAbc();
+            }
+        }
+        /**
          * Check for dot + space
          */
-        if (isDotSpaceEnabled && code == space && inputConnection.getTextBeforeCursor(2, 0).charAt(0) == '.' && !isShiftOn) {
+        else if (isDotSpaceEnabled && code == space && inputConnection.getTextBeforeCursor(2, 0).charAt(0) == '.' && !isShiftOn) {
             isShiftOn = true;
             updateOnShift();
             if (currentLayout == PrefData.VAL_LAYOUT_NUMBER || currentLayout == PrefData.VAL_LAYOUT_SYMBOL) {
@@ -1523,6 +1545,9 @@ public class KeyboardService extends InputMethodService implements
                 break;
             case PrefData.KEY_IS_DOT_SPACE_ENABLED_B:
                 isDotSpaceEnabled = PrefData.getBooleanPrefs(this, PrefData.KEY_IS_DOT_SPACE_ENABLED_B);
+                break;
+            case PrefData.KEY_IS_ANY_SPACE_ENABLED_B:
+                isAnySpaceEnabled = PrefData.getBooleanPrefs(this, PrefData.KEY_IS_ANY_SPACE_ENABLED_B);
                 break;
             case PrefData.KEY_IS_PREVIEW_ENABLED_B:
                 isPreviewOn = PrefData.getBooleanPrefs(this, PrefData.KEY_IS_PREVIEW_ENABLED_B);

--- a/app/src/main/java/it/keybeeproject/keybee/service/KeyboardService.java
+++ b/app/src/main/java/it/keybeeproject/keybee/service/KeyboardService.java
@@ -208,7 +208,7 @@ public class KeyboardService extends InputMethodService implements
         isSoundEnabled = PrefData.getBooleanPrefs(this, PrefData.KEY_IS_SOUND_ENABLED_B);
         isVibraEnabled = PrefData.getBooleanPrefs(this, PrefData.KEY_IS_VIBRA_ENABLED_B);
         isDotSpaceEnabled = PrefData.getBooleanPrefs(this, PrefData.KEY_IS_DOT_SPACE_ENABLED_B, true);
-        isMainAfterSpaceEnabled = PrefData.getBooleanPrefs(this, PrefData.KEY_IS_MAIN_AFTER_SPACE_ENABLED_B, true);
+        isMainAfterSpaceEnabled = PrefData.getBooleanPrefs(this, PrefData.KEY_IS_MAIN_AFTER_SPACE_ENABLED_B, false);
         isPreviewOn = PrefData.getBooleanPrefs(this, PrefData.KEY_IS_PREVIEW_ENABLED_B, true);
         isTwipeEnabled = PrefData.getBooleanPrefs(this, PrefData.KEY_IS_TWIPE_ENABLED_B, true);
         isCursorEnabled = PrefData.getBooleanPrefs(this, PrefData.KEY_IS_CURSOR_ENABLED_B, true);

--- a/app/src/main/java/it/keybeeproject/keybee/service/KeyboardService.java
+++ b/app/src/main/java/it/keybeeproject/keybee/service/KeyboardService.java
@@ -579,12 +579,21 @@ public class KeyboardService extends InputMethodService implements
                 case KeyEvent.KEYCODE_DEL:
                     updateOnBackSpace();
 
-                    /**
-                     * Check for dot + space
-                     */
                     String currentText = getCurrentInputConnection().getTextBeforeCursor(2, 0).toString();
                     if (currentText != null && currentText.length() > 1) {
-                        if (isDotSpaceEnabled && currentText.equals(". ") && !isShiftOn) {
+                        /**
+                         * Check for punctuation + space
+                         */
+                        if (isAnySpaceEnabled &&
+                                currentText.charAt(1) == ' ' &&
+                                ArrayUtils.contains(PUNCTUATION_CHARS_REQUIRING_CAPITALIZATION, currentText.charAt(0))) {
+                            isShiftOn = true;
+                            updateOnShift();
+                        }
+                        /**
+                         * Check for dot + space
+                         */
+                        else if (isDotSpaceEnabled && currentText.equals(". ") && !isShiftOn) {
                             isShiftOn = true;
                             updateOnShift();
                         } else if (isShiftOn && !isCapsLockOn) {

--- a/app/src/main/java/it/keybeeproject/keybee/utility/PrefData.java
+++ b/app/src/main/java/it/keybeeproject/keybee/utility/PrefData.java
@@ -34,7 +34,7 @@ public class PrefData {
 	public static final String KEY_KEYBOARD_LAYOUT_CUSTOMPOPUP = "keyboardLayout_custom_popup";
 	public static final String KEY_KEYBOARD_LANGUAGE_I = "keyboardLanguage";
     public static final String KEY_IS_DOT_SPACE_ENABLED_B = "isDotSpaceEnabled";
-    public static final String KEY_IS_ANY_SPACE_ENABLED_B = "isAnySpaceEnabled";
+    public static final String KEY_IS_MAIN_AFTER_SPACE_ENABLED_B = "isMainAfterSpaceEnabled";
     public static final String KEY_IS_PREVIEW_ENABLED_B = "isPreviewEnabled";
     public static final String KEY_IS_TWIPE_ENABLED_B = "isTwipeEnabled";
     public static final String KEY_IS_CURSOR_ENABLED_B = "isCursorEnabled";

--- a/app/src/main/java/it/keybeeproject/keybee/utility/PrefData.java
+++ b/app/src/main/java/it/keybeeproject/keybee/utility/PrefData.java
@@ -34,6 +34,7 @@ public class PrefData {
 	public static final String KEY_KEYBOARD_LAYOUT_CUSTOMPOPUP = "keyboardLayout_custom_popup";
 	public static final String KEY_KEYBOARD_LANGUAGE_I = "keyboardLanguage";
     public static final String KEY_IS_DOT_SPACE_ENABLED_B = "isDotSpaceEnabled";
+    public static final String KEY_IS_ANY_SPACE_ENABLED_B = "isAnySpaceEnabled";
     public static final String KEY_IS_PREVIEW_ENABLED_B = "isPreviewEnabled";
     public static final String KEY_IS_TWIPE_ENABLED_B = "isTwipeEnabled";
     public static final String KEY_IS_CURSOR_ENABLED_B = "isCursorEnabled";

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -392,26 +392,26 @@
             app:custom_font="@string/font_dosis_regular" />
 
         <RelativeLayout
-            android:id="@+id/relative_anySpace"
+            android:id="@+id/relative_mainAfterSpace"
             style="@style/LayoutOption">
 
             <it.keybeeproject.keybee.view.TextViewCustom
-                android:id="@+id/text_anySpace"
+                android:id="@+id/text_mainAfterSpace"
                 style="@style/TextOption"
-                android:layout_toLeftOf="@+id/check_anySpace"
-                android:layout_toStartOf="@+id/check_anySpace"
-                android:text="@string/any_space"
+                android:layout_toLeftOf="@+id/check_mainAfterSpace"
+                android:layout_toStartOf="@+id/check_mainAfterSpace"
+                android:text="@string/main_after_space"
                 app:custom_font="@string/font_dosis_regular" />
 
             <CheckBox
-                android:id="@+id/check_anySpace"
+                android:id="@+id/check_mainAfterSpace"
                 style="@style/CheckOption" />
 
             <it.keybeeproject.keybee.view.TextViewCustom
                 style="@style/TextOptionIntro"
-                android:layout_below="@id/text_anySpace"
-                android:layout_toLeftOf="@id/check_anySpace"
-                android:text="@string/any_space_intro"
+                android:layout_below="@id/text_mainAfterSpace"
+                android:layout_toLeftOf="@id/check_mainAfterSpace"
+                android:text="@string/main_after_space_intro"
                 app:custom_font="@string/font_dosis_regular" />
         </RelativeLayout>
 

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -392,6 +392,30 @@
             app:custom_font="@string/font_dosis_regular" />
 
         <RelativeLayout
+            android:id="@+id/relative_anySpace"
+            style="@style/LayoutOption">
+
+            <it.keybeeproject.keybee.view.TextViewCustom
+                android:id="@+id/text_anySpace"
+                style="@style/TextOption"
+                android:layout_toLeftOf="@+id/check_anySpace"
+                android:layout_toStartOf="@+id/check_anySpace"
+                android:text="@string/any_space"
+                app:custom_font="@string/font_dosis_regular" />
+
+            <CheckBox
+                android:id="@+id/check_anySpace"
+                style="@style/CheckOption" />
+
+            <it.keybeeproject.keybee.view.TextViewCustom
+                style="@style/TextOptionIntro"
+                android:layout_below="@id/text_anySpace"
+                android:layout_toLeftOf="@id/check_anySpace"
+                android:text="@string/any_space_intro"
+                app:custom_font="@string/font_dosis_regular" />
+        </RelativeLayout>
+
+        <RelativeLayout
             android:id="@+id/relative_dotSpace"
             style="@style/LayoutOption">
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -39,6 +39,8 @@
     <string name="text_settings">Text settings</string>
     <string name="dot_space">Dot + space</string>
     <string name="dot_space_intro">Go to main keyboard after dot + space</string>
+    <string name="any_space">Any space</string>
+    <string name="any_space_intro">Go to main keyboard after pressing space</string>
     <string name="letter_preview">Letter preview</string>
     <string name="letter_preview_intro">Show the preview on key press</string>
     <string name="feedback_settings">Feedback settings</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -39,8 +39,8 @@
     <string name="text_settings">Text settings</string>
     <string name="dot_space">Dot + space</string>
     <string name="dot_space_intro">Go to main keyboard after dot + space</string>
-    <string name="any_space">Any space</string>
-    <string name="any_space_intro">Go to main keyboard after pressing space</string>
+    <string name="main_after_space">Main after space</string>
+    <string name="main_after_space_intro">Go to main keyboard after pressing space</string>
     <string name="letter_preview">Letter preview</string>
     <string name="letter_preview_intro">Show the preview on key press</string>
     <string name="feedback_settings">Feedback settings</string>


### PR DESCRIPTION
This adds a setting to switch back to the main abc keyboard after hitting space in any of the sub keyboards. I also have logic to disable the `Dot Space` feature when this is enabled, since it encompasses the same logic.

I am open to suggestions for changing the name/text/anything

<img width="264" height="172" alt="image" src="https://github.com/user-attachments/assets/ddcb6957-83d0-425c-b9c6-b63f7e8645f1" />

I have been using this for a few days and it's been great.