### PR TITLE
Set checkbox alpha to look disabled

### DIFF
--- a/app/src/main/java/it/keybeeproject/keybee/activity/SettingsActivity.java
+++ b/app/src/main/java/it/keybeeproject/keybee/activity/SettingsActivity.java
@@ -596,12 +596,14 @@ public class SettingsActivity extends AppCompatActivity {
 
     private void enableOtherSizeSettings(boolean enable) {
         int textColor = enable ? getResources().getColor(R.color.black) : getResources().getColor(R.color.text_gray);
+        float checkAlpha = enable ? 1.0f : 0.4f;
         linearSize.setEnabled(enable);
         textSize.setTextColor(textColor);
         linearAlignment.setEnabled(enable);
         textAlignment.setTextColor(textColor);
         relativeLateralGap.setEnabled(enable);
         textLateralGap.setTextColor(textColor);
+        checkLateralGapFill.setAlpha(checkAlpha);
     }
 
     @Override


### PR DESCRIPTION
Minor cosmetic change to make it look like checkboxes are disabled when they actually are.
<img width="262" height="223" alt="image" src="https://github.com/user-attachments/assets/f04f28b9-3a72-4bef-85bb-fcf766b59415" />
